### PR TITLE
Fix General SQL Error while saving Emoji in DB.

### DIFF
--- a/controller/editlog.php
+++ b/controller/editlog.php
@@ -146,6 +146,7 @@ class editlog
 							WHERE edit_id = {$options[0]} AND post_id = {$post_id}";
 					$result = $this->db->sql_query($sql);
 					$new_text = $this->db->sql_fetchfield('old_text');
+					decode_message($new_text);
 					$this->db->sql_freeresult($result);
 				}
 
@@ -154,6 +155,7 @@ class editlog
 						WHERE edit_id = {$options[1]} AND post_id = {$post_id}";
 				$result = $this->db->sql_query($sql);
 				$old_text = $this->db->sql_fetchfield('old_text');
+				decode_message($old_text);
 				$this->db->sql_freeresult($result);
 
 				if (!$old_text || !$new_text)

--- a/controller/editlog.php
+++ b/controller/editlog.php
@@ -165,7 +165,8 @@ class editlog
 
 				if ($old_text == $new_text)
 				{
-					$content = html_entity_decode($old_text);
+					$content = nl2br($new_text);
+					$content = html_entity_decode($content);
 				}
 				else
 				{

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -161,8 +161,6 @@ class main_listener implements EventSubscriberInterface
                 $sql_data[POSTS_TABLE]['sql']['post_edit_reason'] = trim($sql_data[POSTS_TABLE]['sql']['post_edit_reason']);
                 $sql_data[POSTS_TABLE]['sql']['post_edit_log'] = true;
 
-				decode_message($old_post['post_text'], $old_post['bbcode_uid']);
-
 				$insert_array = array(
 					'post_id'	=> $event['data']['post_id'],
 					'user_id'	=> $old_post['post_edit_user'],


### PR DESCRIPTION
@ktowen , Respected Sir/Madam,    

When the Old Post had a Special Char Emoji like `👎` , caused an SQL General Error after Submitting the New Post.    
The Old Contend & the New Contend's of Post were not saved to it's respective DB.    

Following are the ScreenShot of the Same ::    
     
Error ScreenShot :    
![1](https://s5.postimg.org/w3vb9teuv/SQLGE.png)    
     
BackTrace ScreenShot :    
![2](https://s5.postimg.org/9gg23nzav/log_Error.png)    
     
## Solution : ##     
The BBcode decoded contend changes the Emoji like `👎` to some format that is Invalid value for SQL.    
The Error was caused because the SQL could not handle such Char in its DB due to Invalid Value.    
So to circumvent the Error , I did not save BBcode decoded Old Post contend to SQL DB , BUT the Original as-is contend to SQL DB.    
Then while Comparing (OR before Comparing) , I Decode the Old Post contend to BBcode Format for comparison between Old & New.    
This way there are NO Error's and Decode only when Needed.    
      
PS: I like your Ext , It's awesome. Thanks for the same. 😄 👍       
     
Thanking you.    
👍 😀 